### PR TITLE
Correct default value of WeakRefString.ind

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -28,7 +28,7 @@ struct WeakRefString{T} <: AbstractString
     ind::Int # used to keep track of a string data index
 end
 
-WeakRefString(ptr::Ptr{T}, len) where {T} = WeakRefString(ptr, Int(len), 0)
+WeakRefString(ptr::Ptr{T}, len) where {T} = WeakRefString(ptr, Int(len), 1)
 WeakRefString(t::Tuple{Ptr{T}, Int, Int}) where {T} = WeakRefString(t[1], t[2], t[3])
 
 const NULLSTRING = WeakRefString(Ptr{UInt8}(0), 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,10 +2,10 @@ using WeakRefStrings
 using Base.Test
 
 if !isdefined(Core, :String)
-    typealias String UTF8String
+    const String = UTF8String
 end
 
-data = "hey there sailor".data
+data = Vector{UInt8}("hey there sailor")
 
 str = WeakRefString(pointer(data), 3)
 str2 = WeakRefString(pointer(data), 3, 1)
@@ -21,10 +21,10 @@ end
 
 io = IOBuffer()
 show(io, str)
-@test takebuf_string(io) == "\"hey\""
+@test String(take!(io)) == "\"hey\""
 
 show(io, typeof(str))
-@test takebuf_string(io) == "WeakRefString{UInt8}"
+@test String(take!(io)) == "WeakRefString{UInt8}"
 
 # simulate UTF16 data
 data = reinterpret(UInt16, [0x68, 0x00, 0x65, 0x00, 0x79, 0x00])
@@ -47,3 +47,20 @@ str = WeakRefString(pointer(data), 4)
 for (i,c) in enumerate(str)
     @test data[i] == c % UInt8
 end
+
+# Verify that the ind field works as expected (as the index in a call to pointer)
+data = Vector{UInt8}("some test data")
+ptr = pointer(data)
+wrs = WeakRefString(ptr, 4)
+@test wrs == "some"
+@test pointer(data, wrs.ind) == ptr
+
+ptr = pointer(data, 1)
+wrs = WeakRefString(ptr, 4, 1)
+@test wrs == "some"
+@test pointer(data, wrs.ind) == ptr
+
+ptr = pointer(data, 6)
+wrs = WeakRefString(ptr, 4, 6)
+@test wrs == "test"
+@test pointer(data, wrs.ind) == ptr


### PR DESCRIPTION
Because it's a pointer index, and calls to `pointer` are zero-indexed, "no offset" should be 1, rather than zero. Correct the two-argument constructor to reflect this.

Closes #8