### PR TITLE
Add push!()

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -94,6 +94,7 @@ Base.setindex!(A::WeakRefStringArray{T, N}, v::String, i::Int) where {T, N} = (p
 Base.setindex!(A::WeakRefStringArray{T, N}, v::String, I::Vararg{Int, N}) where {T, N} = (push!(A.data, Vector{UInt8}(v)); setindex!(A.elements, v, I...))
 Base.resize!(A::WeakRefStringArray, i) = resize!(A.elements, i)
 
+Base.push!(a::WeakRefStringArray{T, 1}, v::Null) where {T} = (push!(a.elements, v); a)
 Base.push!(a::WeakRefStringArray{T, 1}, v::WeakRefString) where {T} = (push!(a.elements, v); a)
 function Base.push!(A::WeakRefStringArray{T, 1}, v::String) where T
     push!(A.data, Vector{UInt8}(v))

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -94,6 +94,13 @@ Base.setindex!(A::WeakRefStringArray{T, N}, v::String, i::Int) where {T, N} = (p
 Base.setindex!(A::WeakRefStringArray{T, N}, v::String, I::Vararg{Int, N}) where {T, N} = (push!(A.data, Vector{UInt8}(v)); setindex!(A.elements, v, I...))
 Base.resize!(A::WeakRefStringArray, i) = resize!(A.elements, i)
 
+Base.push!(a::WeakRefStringArray{T, 1}, v::WeakRefString) where {T} = (push!(a.elements, v); a)
+function Base.push!(A::WeakRefStringArray{T, 1}, v::String) where T
+    push!(A.data, Vector{UInt8}(v))
+    push!(A.elements, v)
+    return A
+end
+
 function Base.append!(a::WeakRefStringArray{T, 1}, b::WeakRefStringArray{T, 1}) where {T}
     append!(a.data, b.data)
     append!(a.elements, b.elements)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using WeakRefStrings, Base.Test
+using WeakRefStrings, Base.Test, Nulls
 
 @testset "WeakRefString{UInt8}" begin
     data = Vector{UInt8}("hey there sailor")
@@ -72,4 +72,14 @@ end
     B[1] = "ho"
     append!(A, B)
     @test size(A) == (17,)
+
+    D = WeakRefStringArray(UInt8[], Union{Null, WeakRefString{UInt8}}, 0)
+    push!(D, "hey")
+    push!(D, str)
+    push!(D, null)
+    @test length(D) == 3
+    @test D[2] == str
+    @test D[3] === null
+    D[2] = null
+    @test D[2] === null
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,9 +61,15 @@ end
     @test A[1] == "hey"
     resize!(A, 5)
     @test size(A) == (5,)
+    push!(A, str)
+    @test size(A) == (6,)
+    @test A[end] == str
+    push!(A, "hi")
+    @test length(A) == 7
+    @test A[end] == convert(WeakRefString{UInt8}, "hi")
 
     B = WeakRefStringArray(UInt8[], WeakRefString{UInt8}, 10)
     B[1] = "ho"
     append!(A, B)
-    @test size(A) == (15,)
+    @test size(A) == (17,)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,57 +1,69 @@
 using WeakRefStrings, Base.Test
 
-data = Vector{UInt8}("hey there sailor")
+@testset "WeakRefString{UInt8}" begin
+    data = Vector{UInt8}("hey there sailor")
 
-str = WeakRefString(pointer(data), 3)
+    str = WeakRefString(pointer(data), 3)
 
-@test length(str) == 3
-for (i,c) in enumerate(str)
-    @test data[i] == c % UInt8
-end
-@test string(str) == "hey"
-@test String(str) == "hey"
+    @test length(str) == 3
+    for (i,c) in enumerate(str)
+        @test data[i] == c % UInt8
+    end
+    @test string(str) == "hey"
+    @test String(str) == "hey"
 
-io = IOBuffer()
-show(io, str)
-@test String(take!(io)) == "\"hey\""
+    io = IOBuffer()
+    show(io, str)
+    @test String(take!(io)) == "\"hey\""
 
-show(io, typeof(str))
-@test String(take!(io)) == "WeakRefString{UInt8}"
-
-A = WeakRefStringArray(data, [str])
-
-# simulate UTF16 data
-data = [0x0068, 0x0065, 0x0079]
-
-str = WeakRefString(pointer(data), 3)
-@test typeof(str) == WeakRefString{UInt16}
-@test String(str) == "hey"
-@test length(str) == 3
-for (i,c) in enumerate(str)
-    @test data[i] == c % UInt8
+    show(io, typeof(str))
+    @test String(take!(io)) == "WeakRefString{UInt8}"
 end
 
-# simulate UTF32 data with trailing null byte
-data = [0x00000068, 0x00000065, 0x00000079, 0x00000000]
+@testset "WeakRefString{UInt16}" begin
+    # simulate UTF16 data
+    data = [0x0068, 0x0065, 0x0079]
 
-str = WeakRefString(pointer(data), 4)
-@test typeof(str) == WeakRefString{UInt32}
-@test String(str) == "hey"
-@test length(str) == 4
-for (i,c) in enumerate(str)
-    @test data[i] == c % UInt8
+    str = WeakRefString(pointer(data), 3)
+    @test typeof(str) == WeakRefString{UInt16}
+    @test String(str) == "hey"
+    @test length(str) == 3
+    for (i,c) in enumerate(str)
+        @test data[i] == c % UInt8
+    end
 end
 
-A = WeakRefStringArray(UInt8[], WeakRefString{UInt8}, 10)
-@test size(A) == (10,)
-@test A[1] == ""
-@test A[1, 1] == ""
-A[1] = "hey"
-A[1, 1] = "hey"
-@test A[1] == "hey"
-resize!(A, 5)
-@test size(A) == (5,)
-B = WeakRefStringArray(UInt8[], WeakRefString{UInt8}, 10)
-B[1] = "ho"
-append!(A, B)
-@test size(A) == (15,)
+@testset "WeakRefString{UInt32}" begin
+    # simulate UTF32 data with trailing null byte
+    data = [0x00000068, 0x00000065, 0x00000079, 0x00000000]
+
+    str = WeakRefString(pointer(data), 4)
+    @test typeof(str) == WeakRefString{UInt32}
+    @test String(str) == "hey"
+    @test length(str) == 4
+    for (i,c) in enumerate(str)
+        @test data[i] == c % UInt8
+    end
+end
+
+@testset "WeakRefArray" begin
+    data = Vector{UInt8}("hey there sailor")
+    str = WeakRefString(pointer(data), 3)
+    C = WeakRefStringArray(data, [str])
+    @test length(C) == 1
+
+    A = WeakRefStringArray(UInt8[], WeakRefString{UInt8}, 10)
+    @test size(A) == (10,)
+    @test A[1] == ""
+    @test A[1, 1] == ""
+    A[1] = "hey"
+    A[1, 1] = "hey"
+    @test A[1] == "hey"
+    resize!(A, 5)
+    @test size(A) == (5,)
+
+    B = WeakRefStringArray(UInt8[], WeakRefString{UInt8}, 10)
+    B[1] = "ho"
+    append!(A, B)
+    @test size(A) == (15,)
+end


### PR DESCRIPTION
I've added `push!()`, because `DataFrames.streamto!()` method gave the following exception while trying to load the data from `.csv`:
```
  MethodError: no method matching push!(::WeakRefStrings.WeakRefStringArray{WeakRefString{UInt8},1}, ::WeakRefString{UInt8})
  Closest candidates are:
    push!(::Any, ::Any, ::Any) at abstractarray.jl:1935
    push!(::Any, ::Any, ::Any, ::Any...) at abstractarray.jl:1936
    push!(::Array{Any,1}, ::ANY) at array.jl:624
    ...
  Stacktrace:
   [1] streamto! at /fs/home/<>/.julia/v0.6/DataFrames/src/abstractdataframe/io.jl:294 [inlined]
   [2] macro expansion at /fs/home/<>/.julia/v0.6/DataStreams/src/DataStreams.jl:277 [inlined]
   [3] stream!(::CSV.Source{Base.AbstractIOBuffer{Array{UInt8,1}},Nulls.Null}, ::Type{DataStreams.Data.Field}, ::DataFrames.DataFrameStream{Tuple{WeakRefStrings.WeakRefStringArray{WeakRefString{UInt8},1},Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1}}}, ::DataStreams.Data.Schema{false,Tuple{WeakRefString{UInt8},Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64}}, ::Int64, ::NTuple{15,Base.#identity}, ::DataStreams.Data.##15#16, ::Array{Any,1}) at /fs/home/<>/.julia/v0.6/DataStreams/src/DataStreams.jl:344
   [4] #stream!#17(::Bool, ::Dict{Int64,Function}, ::Function, ::Array{Any,1}, ::Array{Any,1}, ::Function, ::CSV.Source{Base.AbstractIOBuffer{Array{UInt8,1}},Nulls.Null}, ::Type{DataFrames.DataFrame}) at /fs/home/<>/.julia/v0.6/DataStreams/src/DataStreams.jl:222
   [5] (::DataStreams.Data.#kw##stream!)(::Array{Any,1}, ::DataStreams.Data.#stream!, ::CSV.Source{Base.AbstractIOBuffer{Array{UInt8,1}},Nulls.Null}, ::Type{DataFrames.DataFrame}) at ./<missing>:0
   [6] #read#39(::Bool, ::Dict{Int64,Function}, ::Bool, ::Array{Any,1}, ::Function, ::TranscodingStreams.TranscodingStream{CodecZlib.GzipDecompression,IOStream}, ::Type{T} where T) at /fs/home/<>/.julia/v0.6/CSV/src/Source.jl:311
```
Also I've annotated the tests with `@testset`, because the fact that some vars (`data`, `str`) are redefined generates some confusion when writing tests.
