### PR TITLE
fix #14

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -112,7 +112,6 @@ function Base.append!(a::WeakRefStringArray{T, 1}, b::WeakRefStringArray{T, 1}) 
     return a
 end
 
-import Base.vcat
 function Base.vcat(a::WeakRefStringArray{T, 1}, b::WeakRefStringArray{T, 1}) where T
     WeakRefStringArray(Any[a.data, b.data], vcat(a.elements, b.elements))
 end

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -112,4 +112,9 @@ function Base.append!(a::WeakRefStringArray{T, 1}, b::WeakRefStringArray{T, 1}) 
     return a
 end
 
+import Base.vcat
+function Base.vcat(a::WeakRefStringArray{T, 1}, b::WeakRefStringArray{T, 1}) where T
+    WeakRefStringArray(Any[a.data, b.data], vcat(a.elements, b.elements))
+end
+
 end # module


### PR DESCRIPTION
This appears to fix #14.  Note that I did this without really understanding what was causing the error, though clearly `vcat` in `Base` was doing something completely bogus to `WeakRefStringArray`.

After some more checking, this does *not* seem to fix DataFrame concatenation!  I still can't figure out how to fix that.