### PR TITLE
Stop lying about WeakRefStringArray eltype

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -75,7 +75,7 @@ Base.convert(::Type{String}, x::WeakRefString) = convert(String, string(x))
 Base.String(x::WeakRefString) = string(x)
 Base.Symbol(x::WeakRefString{UInt8}) = ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int), x.ptr, x.len)
 
-struct WeakRefStringArray{T, N} <: AbstractArray{T, N}
+struct WeakRefStringArray{T, N} <: AbstractArray{Union{String, Missing}, N}
     data::Vector{Any}
     elements::Array{T, N}
 end


### PR DESCRIPTION
`getindex()` always returns a `String`, never a `WeakRefString`.

See https://github.com/JuliaData/CSV.jl/pull/118#discussion_r153446137.