### PR TITLE
WeakRefStringArray: make eltype respect Missing

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -18,6 +18,8 @@ Internally, a `WeakRefString{T}` holds:
 
   * `ptr::Ptr{T}`: a pointer to the string data (code unit size is parameterized on `T`)
   * `len::Int`: the number of code units in the string data
+
+See also [`WeakRefStringArray`](@ref)
 """
 struct WeakRefString{T} <: AbstractString
     ptr::Ptr{T}
@@ -76,6 +78,14 @@ Base.convert(::Type{String}, x::WeakRefString) = convert(String, string(x))
 Base.String(x::WeakRefString) = string(x)
 Base.Symbol(x::WeakRefString{UInt8}) = ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int), x.ptr, x.len)
 
+"""
+A [`WeakRefString`](@ref) container.
+Holds the "strong" references to the data pointed by its strings, ensuring that
+the referenced memory blocks stay valid during `WeakRefStringArray` lifetime.
+
+Otherwise, `WeakRefStringArray` behaves like a normal array of `String` elements
+(or `Union{String, Missing}`, if missing values are allowed).
+"""
 struct WeakRefStringArray{T<:WeakRefString, N, U} <: AbstractArray{Union{String, U}, N}
     data::Vector{Any}
     elements::Array{Union{T, U}, N}

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -75,7 +75,7 @@ Base.convert(::Type{String}, x::WeakRefString) = convert(String, string(x))
 Base.String(x::WeakRefString) = string(x)
 Base.Symbol(x::WeakRefString{UInt8}) = ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int), x.ptr, x.len)
 
-struct WeakRefStringArray{T, N, U} <: AbstractArray{Union{String, U}, N}
+struct WeakRefStringArray{T<:WeakRefString, N, U} <: AbstractArray{Union{String, U}, N}
     data::Vector{Any}
     elements::Array{Union{T, U}, N}
 

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -36,6 +36,9 @@ Base.zero(::Type{WeakRefString{T}}) where {T} = WeakRefString(Ptr{T}(0), 0)
 Base.endof(x::WeakRefString) = endof(string(x))
 Base.length(x::WeakRefString) = length(string(x))
 Base.next(x::WeakRefString, i::Int) = (Char(unsafe_load(x.ptr, i)), i + 1)
+if isdefined(Base, :ncodeunits) # around v"0.7.0-DEV.2915"
+    Base.ncodeunits(x::WeakRefString) = x.len
+end
 
 import Base: ==
 function ==(x::WeakRefString{T}, y::WeakRefString{T}) where {T}

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -6,12 +6,13 @@ export WeakRefString, WeakRefStringArray
 using Missings
 
 """
-A custom "weakref" string type that only points to external string data.
-Allows for the creation of a "string" instance without copying data,
-which allows for more efficient string parsing/movement in certain data processing tasks.
+A custom "weak reference" string type that only points to external string data, but does
+not own it. Allows for the creation of a "string" instance without copying the data,
+which provides more efficient string parsing/movement in certain data processing tasks.
 
-**Please note that no original reference is kept to the parent string/memory, so `WeakRefString` becomes unsafe
-once the parent object goes out of scope (i.e. loses a reference to it)**
+**Please note that no original reference is kept to the parent string/memory,
+so `WeakRefString` becomes unsafe once the parent object goes out of scope
+(i.e. loses a reference to it)**
 
 Internally, a `WeakRefString{T}` holds:
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,7 @@ end
     str = WeakRefString(pointer(data), 3)
     C = WeakRefStringArray(data, [str])
     @test size(C) == (1,)
+    @test eltype(C) === String
 
     A = WeakRefStringArray(UInt8[], WeakRefString{UInt8}, 10)
     @test size(A) == (10,)
@@ -72,6 +73,8 @@ end
     B[1] = "ho"
     append!(A, B)
     @test size(A) == (17,)
+    @test_throws MethodError setindex!(B, missing, 1)
+    @test_throws MethodError push!(B, missing)
 
     D = WeakRefStringArray(UInt8[], Union{Missing, WeakRefString{UInt8}}, 0)
     push!(D, "hey")
@@ -82,4 +85,10 @@ end
     @test D[3] === missing
     D[2] = missing
     @test D[2] === missing
+    @test_throws MethodError append!(A, D)
+    @test_broken size(A) == (17,) # append!() changes the size of A
+
+    E = WeakRefStringArray(data, [str missing])
+    @test size(E) == (1, 2)
+    @test eltype(E) === Union{String, Missing}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,7 +50,7 @@ end
     data = Vector{UInt8}("hey there sailor")
     str = WeakRefString(pointer(data), 3)
     C = WeakRefStringArray(data, [str])
-    @test length(C) == 1
+    @test size(C) == (1,)
 
     A = WeakRefStringArray(UInt8[], WeakRefString{UInt8}, 10)
     @test size(A) == (10,)
@@ -77,7 +77,7 @@ end
     push!(D, "hey")
     push!(D, str)
     push!(D, missing)
-    @test length(D) == 3
+    @test size(D) == (3,)
     @test D[2] == str
     @test D[3] === missing
     D[2] = missing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,4 +91,12 @@ end
     E = WeakRefStringArray(data, [str missing])
     @test size(E) == (1, 2)
     @test eltype(E) === Union{String, Missing}
+
+    # WeakRefStringArray only supports WeakRefString elements
+    @test_throws MethodError WeakRefStringArray(UInt8[], String, 0)
+    @test_throws MethodError WeakRefStringArray(UInt8[], Int, 0)
+    @test_throws MethodError WeakRefStringArray(UInt8[], Union{String, Missing}, 0)
+    @test_throws MethodError WeakRefStringArray(UInt8[], Union{Int, Missing}, 0)
+    @test_throws MethodError WeakRefStringArray(UInt8[], [1, 2])
+    @test_throws MethodError WeakRefStringArray(UInt8[], [1.0, missing])
 end


### PR DESCRIPTION
Enhances #17 so that WeakRefStringArray allows missing iff
the underlying WeakRefString Array allows missing.

Should fix the eltypes of the dataframes returned by CSV.jl.

~~Needs tests.~~