### PR TITLE
Clarify WeakRefStrings purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # WeakRefStrings
 
-*An alternative string storage format for Julia*
+*A string type for minimizing data-transfer costs in Julia*
 
 | **PackageEvaluator**                                            | **Build Status**                                                                                |
 |:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
@@ -41,33 +41,6 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 
 ## Usage
 
-A custom "weakref" string type that only points to external string data.
-Allows for the creation of a "string" instance without copying data,
-which allows for more efficient string parsing/movement in certain data processing tasks.
+Usage of `WeakRefString`s is discouraged for general users. Currently, a `WeakRefString` purposely _does not_ implement many Base Julia String interface methods due to many recent changes to Julia's builtin String interface, as well as the complexity to do so correctly. As such, `WeakRefString`s are used primarily in the data ecosystem as an IO optimization and nothing more. Upon indexing a `WeakRefStringArray`, a proper Julia `String` type is materialized for safe, correct string processing. In the future, it may be possible to implement safe operations on `WeakRefString` itself, but for now, they must be converted to a `String` for any real work.
 
-**Please note that no original reference is kept to the parent string/memory, so `WeakRefString` becomes unsafe
-once the parent object goes out of scope (i.e. loses a reference to it)**
-
-Internally, a `WeakRefString{T}` holds:
-
-  * `ptr::Ptr{T}`: a pointer to the string data (code unit size is parameterized on `T`)
-  * `len::Int`: the number of code units in the string data
-
-
-```julia
-data = Vector{UInt8}("hey there sailor")
-
-str = WeakRefString(pointer(data), 3)
-@test length(str) == 3
-for (i,c) in enumerate(str)
-    @test data[i] == c % UInt8
-end
-@test string(str) == "hey"
-```
-
-To facilitate using WeakRefStrings, a `WeakRefStringArray` type is provided that can simultaneously act as an `Array{WeakRefString{T}, N}` while also holding on to data references that the WeakRefStrings point to. Usage, is simple:
-```julia
-WeakRefStringArray(data::Vector{UInt8}, ::Type{T}, rows) => WeakRefStringArray{T, 1}
-WeakRefStringArray(data::Vector{UInt8}, A::Array{WeakRefString{T}, N}) => WeakRefStringArray{T, N}
-```
-In both cases, the first argument passed is the data that should be held in reference. An "empty" WeakRefString can be constructed by passing the WeakRefString element type and a number of rows, or an already constructed Array of WeakRefStrings can be passed in directly.
+Additional documentation is available at the REPL for `?WeakRefStringArray` and `?WeakRefString`.

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -5,6 +5,10 @@ export WeakRefString, WeakRefStringArray
 
 using Missings
 
+if !isdefined(Base, :codeunits)
+    codeunits = Vector{UInt8}
+end
+
 """
 A custom "weakref" string type that only points to external string data.
 Allows for the creation of a "string" instance without copying data,
@@ -119,14 +123,14 @@ Base.setindex!(A::WeakRefStringArray{T, N}, v::Missing, i::Int) where {T, N} = s
 Base.setindex!(A::WeakRefStringArray{T, N}, v::Missing, I::Vararg{Int, N}) where {T, N} = setindex!(A.elements, v, I...)
 Base.setindex!(A::WeakRefStringArray{T, N}, v::WeakRefString, i::Int) where {T, N} = setindex!(A.elements, v, i)
 Base.setindex!(A::WeakRefStringArray{T, N}, v::WeakRefString, I::Vararg{Int, N}) where {T, N} = setindex!(A.elements, v, I...)
-Base.setindex!(A::WeakRefStringArray{T, N}, v::String, i::Int) where {T, N} = (push!(A.data, Vector{UInt8}(v)); setindex!(A.elements, v, i))
-Base.setindex!(A::WeakRefStringArray{T, N}, v::String, I::Vararg{Int, N}) where {T, N} = (push!(A.data, Vector{UInt8}(v)); setindex!(A.elements, v, I...))
+Base.setindex!(A::WeakRefStringArray{T, N}, v::String, i::Int) where {T, N} = (push!(A.data, codeunits(v)); setindex!(A.elements, v, i))
+Base.setindex!(A::WeakRefStringArray{T, N}, v::String, I::Vararg{Int, N}) where {T, N} = (push!(A.data, codeunits(v)); setindex!(A.elements, v, I...))
 Base.resize!(A::WeakRefStringArray, i) = resize!(A.elements, i)
 
 Base.push!(a::WeakRefStringArray{T, 1}, v::Missing) where {T} = (push!(a.elements, v); a)
 Base.push!(a::WeakRefStringArray{T, 1}, v::WeakRefString) where {T} = (push!(a.elements, v); a)
 function Base.push!(A::WeakRefStringArray{T, 1}, v::String) where T
-    push!(A.data, Vector{UInt8}(v))
+    push!(A.data, codeunits(v))
     push!(A.elements, v)
     return A
 end

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -17,6 +17,8 @@ Internally, a `WeakRefString{T}` holds:
 
   * `ptr::Ptr{T}`: a pointer to the string data (code unit size is parameterized on `T`)
   * `len::Int`: the number of code units in the string data
+
+See also [`WeakRefStringArray`](@ref)
 """
 struct WeakRefString{T} <: AbstractString
     ptr::Ptr{T}
@@ -30,9 +32,6 @@ const NULLSTRING = WeakRefString(Ptr{UInt8}(0), 0)
 const NULLSTRING16 = WeakRefString(Ptr{UInt16}(0), 0)
 const NULLSTRING32 = WeakRefString(Ptr{UInt32}(0), 0)
 Base.zero(::Type{WeakRefString{T}}) where {T} = WeakRefString(Ptr{T}(0), 0)
-Base.endof(x::WeakRefString) = endof(string(x))
-Base.length(x::WeakRefString) = length(string(x))
-Base.next(x::WeakRefString, i::Int) = (Char(unsafe_load(x.ptr, i)), i + 1)
 
 import Base: ==
 function ==(x::WeakRefString{T}, y::WeakRefString{T}) where {T}
@@ -58,10 +57,10 @@ function Base.show(io::IO, x::WeakRefString{T}) where {T}
     return
 end
 Base.print(io::IO, s::WeakRefString) = print(io, string(s))
-if VERSION < v"0.7-DEV"
-    Base.strwidth(s::WeakRefString) = strwidth(string(s))
-else
+if isdefined(Base, :textwidth)
     Base.textwidth(s::WeakRefString) = textwidth(string(s))
+else
+    Base.strwidth(s::WeakRefString) = strwidth(string(s))
 end
 
 chompnull(x::WeakRefString{T}) where {T} = unsafe_load(x.ptr, x.len) == T(0) ? x.len - 1 : x.len
@@ -75,19 +74,45 @@ Base.convert(::Type{String}, x::WeakRefString) = convert(String, string(x))
 Base.String(x::WeakRefString) = string(x)
 Base.Symbol(x::WeakRefString{UInt8}) = ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int), x.ptr, x.len)
 
-struct WeakRefStringArray{T, N} <: AbstractArray{Union{String, Missing}, N}
+"""
+A [`WeakRefString`](@ref) container.
+Holds the "strong" references to the data pointed by its strings, ensuring that
+the referenced memory blocks stay valid during `WeakRefStringArray` lifetime.
+
+Upon indexing an elemnt in a `WeakRefStringArray`, the underlying `WeakRefString` is converted to a proper
+Julia `String` type by copying the memory; this ensures safe string processing in the general case. If additional
+optimizations are desired, the direct `WeakRefString` elements can be accessed by indexing `A.elements`, where
+`A` is a `WeakRefStringArray`.
+"""
+struct WeakRefStringArray{T, N} <: AbstractArray{T, N}
     data::Vector{Any}
     elements::Array{T, N}
+
+    function WeakRefStringArray(data::Vector{Any}, A::Array{WeakRefString{T}, N}) where {T, N}
+        new{WeakRefString{T}, N}(data, A)
+    end
+
+    function WeakRefStringArray(data::Vector{Any}, A::Array{Union{WeakRefString{T}, Missing}, N}) where {T, N}
+        new{Union{WeakRefString{T}, Missing}, N}(data, A)
+    end
 end
 
-WeakRefStringArray(data::Vector{UInt8}, ::Type{T}, rows::Integer) where {T <: WeakRefString} = WeakRefStringArray(Any[data], zeros(T, rows))
-WeakRefStringArray(data::Vector{UInt8}, ::Type{Union{Missing, T}}, rows::Integer) where {T} = WeakRefStringArray(Any[data], Vector{Union{Missing, T}}(rows))
-WeakRefStringArray(data::Vector{UInt8}, A::Array{T}) where {T <: Union{WeakRefString, Missing}} = WeakRefStringArray(Any[data], A)
+init(::Type{T}, rows) where {T} = fill(zero(T), rows)
+if !isdefined(Base, :uninitialized)
+    struct Uninitialized end
+    const uninitialized = Uninitialized()
+    Vector{T}(::Uninitialized, rows) where {T} = Vector{T}(rows)
+end
+init(::Type{Union{Missing, T}}, rows) where {T} = Vector{Union{Missing, T}}(uninitialized, rows)
+WeakRefStringArray(data, ::Type{T}, rows::Integer) where {T} = WeakRefStringArray(Any[data], init(T, rows))
+WeakRefStringArray(data, A::Array{T}) where {T <: Union{WeakRefString, Missing}} = WeakRefStringArray(Any[data], A)
 
 wk(w::WeakRefString) = string(w)
 wk(::Missing) = missing
 
 Base.size(A::WeakRefStringArray) = size(A.elements)
+Base.eltype(A::WeakRefStringArray{T}) where {T <: WeakRefString} = String
+Base.eltype(A::WeakRefStringArray{Union{Missing, T}}) where {T <: WeakRefString} = Union{Missing, String}
 Base.getindex(A::WeakRefStringArray, i::Int) = wk(A.elements[i])
 Base.getindex(A::WeakRefStringArray{T, N}, I::Vararg{Int, N}) where {T, N} = wk.(A.elements[I...])
 Base.setindex!(A::WeakRefStringArray{T, N}, v::Missing, i::Int) where {T, N} = setindex!(A.elements, v, i)

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -100,8 +100,10 @@ struct WeakRefStringArray{T<:WeakRefString, N, U} <: AbstractArray{Union{String,
         new{T, 1, Union{}}(data, init(T, rows))
     WeakRefStringArray(data::Vector{Any}, TT::Type{Union{T, Missing}}, rows::Integer) where {T <: WeakRefString} =
         new{T, 1, Missing}(data, init(TT, rows))
-    WeakRefStringArray(data::Vector{Any}, A::Array{T, N}) where {T <: Union{WeakRefString, Missing}, N} =
-        new{Missings.T(T), N, T >: Missing ? Missing : Union{}}(data, A)
+    WeakRefStringArray(data::Vector{Any}, A::Array{Union{T, Missing}, N}) where {T <: WeakRefString, N} =
+        new{T, N, Missing}(data, A)
+    WeakRefStringArray(data::Vector{Any}, A::Array{T, N}) where {T <: WeakRefString, N} =
+        new{T, N, Union{}}(data, A)
 end
 
 WeakRefStringArray(data, ::Type{T}, rows::Integer) where {T} = WeakRefStringArray(Any[data], T, rows)

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -107,14 +107,14 @@ init(::Type{Union{Missing, T}}, rows) where {T} = Vector{Union{Missing, T}}(unin
 WeakRefStringArray(data, ::Type{T}, rows::Integer) where {T} = WeakRefStringArray(Any[data], init(T, rows))
 WeakRefStringArray(data, A::Array{T}) where {T <: Union{WeakRefString, Missing}} = WeakRefStringArray(Any[data], A)
 
-wk(w::WeakRefString) = string(w)
-wk(::Missing) = missing
+wk(A, B::AbstractArray) = WeakRefStringArray(A.data, B)
+wk(A, w::WeakRefString) = string(w)
+wk(A, ::Missing) = missing
 
 Base.size(A::WeakRefStringArray) = size(A.elements)
 Base.eltype(A::WeakRefStringArray{T}) where {T <: WeakRefString} = String
 Base.eltype(A::WeakRefStringArray{Union{Missing, T}}) where {T <: WeakRefString} = Union{Missing, String}
-Base.getindex(A::WeakRefStringArray, i::Int) = wk(A.elements[i])
-Base.getindex(A::WeakRefStringArray{T, N}, I::Vararg{Int, N}) where {T, N} = wk.(A.elements[I...])
+Base.getindex(A::WeakRefStringArray, I...) = wk(A, getindex(A.elements, I...))
 Base.setindex!(A::WeakRefStringArray{T, N}, v::Missing, i::Int) where {T, N} = setindex!(A.elements, v, i)
 Base.setindex!(A::WeakRefStringArray{T, N}, v::Missing, I::Vararg{Int, N}) where {T, N} = setindex!(A.elements, v, I...)
 Base.setindex!(A::WeakRefStringArray{T, N}, v::WeakRefString, i::Int) where {T, N} = setindex!(A.elements, v, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ end
     str = WeakRefStrings.WeakRefString(pointer(data), 3)
     C = WeakRefStringArray(data, [str])
     @test length(C) == 1
-    @test eltype(C) == String
+    @test eltype(C) === String
 
     A = WeakRefStringArray(UInt8[], WeakRefStrings.WeakRefString{UInt8}, 10)
     @test size(A) == (10,)
@@ -79,4 +79,9 @@ end
     @test D[3] === missing
     D[2] = missing
     @test D[2] === missing
+
+    E = WeakRefStringArray(data, [str missing])
+    @test size(E) == (1, 2)
+    @test eltype(E) === Union{String, Missing}
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,15 @@
-using WeakRefStrings, Base.Test, Missings
-
+using WeakRefStrings, Missings
+@static if VERSION < v"0.7.0-DEV.2005"
+    using Base.Test
+else
+    using Test
+end
 @testset "WeakRefString{UInt8}" begin
     data = Vector{UInt8}("hey there sailor")
 
-    str = WeakRefString(pointer(data), 3)
+    str = WeakRefStrings.WeakRefString(pointer(data), 3)
 
-    @test length(str) == 3
-    for (i,c) in enumerate(str)
-        @test data[i] == c % UInt8
-    end
+    @test str.len == 3
     @test string(str) == "hey"
     @test String(str) == "hey"
 
@@ -24,35 +25,30 @@ end
     # simulate UTF16 data
     data = [0x0068, 0x0065, 0x0079]
 
-    str = WeakRefString(pointer(data), 3)
-    @test typeof(str) == WeakRefString{UInt16}
+    str = WeakRefStrings.WeakRefString(pointer(data), 3)
+    @test typeof(str) == WeakRefStrings.WeakRefString{UInt16}
     @test String(str) == "hey"
-    @test length(str) == 3
-    for (i,c) in enumerate(str)
-        @test data[i] == c % UInt8
-    end
+    @test str.len == 3
 end
 
 @testset "WeakRefString{UInt32}" begin
     # simulate UTF32 data with trailing null byte
     data = [0x00000068, 0x00000065, 0x00000079, 0x00000000]
 
-    str = WeakRefString(pointer(data), 4)
-    @test typeof(str) == WeakRefString{UInt32}
+    str = WeakRefStrings.WeakRefString(pointer(data), 4)
+    @test typeof(str) == WeakRefStrings.WeakRefString{UInt32}
     @test String(str) == "hey"
-    @test length(str) == 3
-    for (i,c) in enumerate(str)
-        @test data[i] == c % UInt8
-    end
+    @test str.len == 4
 end
 
 @testset "WeakRefArray" begin
     data = Vector{UInt8}("hey there sailor")
-    str = WeakRefString(pointer(data), 3)
+    str = WeakRefStrings.WeakRefString(pointer(data), 3)
     C = WeakRefStringArray(data, [str])
     @test length(C) == 1
+    @test eltype(C) == String
 
-    A = WeakRefStringArray(UInt8[], WeakRefString{UInt8}, 10)
+    A = WeakRefStringArray(UInt8[], WeakRefStrings.WeakRefString{UInt8}, 10)
     @test size(A) == (10,)
     @test A[1] == ""
     @test A[1, 1] == ""
@@ -66,18 +62,19 @@ end
     @test A[end] == str
     push!(A, "hi")
     @test length(A) == 7
-    @test A[end] == convert(WeakRefString{UInt8}, "hi")
+    @test A[end] == convert(WeakRefStrings.WeakRefString{UInt8}, "hi")
 
-    B = WeakRefStringArray(UInt8[], WeakRefString{UInt8}, 10)
+    B = WeakRefStringArray(UInt8[], WeakRefStrings.WeakRefString{UInt8}, 10)
     B[1] = "ho"
     append!(A, B)
     @test size(A) == (17,)
 
-    D = WeakRefStringArray(UInt8[], Union{Missing, WeakRefString{UInt8}}, 0)
+    D = WeakRefStringArray(UInt8[], Union{Missing, WeakRefStrings.WeakRefString{UInt8}}, 0)
     push!(D, "hey")
     push!(D, str)
     push!(D, missing)
     @test length(D) == 3
+    @test eltype(D) == Union{Missing, String}
     @test D[2] == str
     @test D[3] === missing
     D[2] = missing


### PR DESCRIPTION
Remove a few pitfall functions that allowed direct processing of WeakRefStrings. Clarify in docs that WeakRefStrings are for IO optimization and not actual string processing. Cleanup the WeakRefStringArray type parameters and constructors

cc: @nalimilan @alyst: I see this as step one to the plan in https://github.com/JuliaData/CSV.jl/pull/140

Should resolve #19 (@andreasnoack).